### PR TITLE
add "ignore" setting (and ignore hidden files by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ Link to the manifest from each template. For example:
 
 The static media root, such as "/static" or "http://static.example.com".
 
+### appcache.ignore
+
+A regular expression specifying paths to omit from the manifest. By default,
+hidden files and files in hidden directories are ignored (the default pattern
+is `/[/][.]/`).
+
 ### appcache.network
 
 An array of resource URIs which require a network connection. For example:

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,9 @@
     var format;
 
     function Manifest(config) {
+      var _ref;
       this.config = config;
+      this.ignore = (_ref = this.config.appcache.ignore) != null ? _ref : /[/][.]/;
     }
 
     Manifest.prototype.brunchPlugin = true;
@@ -85,7 +87,7 @@
       walker = new Walker;
       return walker.walk(this.config.paths["public"], function(path) {
         var shasums;
-        if (!/[.]appcache$/.test(path)) {
+        if (!(/[.]appcache$/.test(path) || _this.ignore.test(path))) {
           paths.push(path);
         }
         if (!walker.walking) {

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -43,6 +43,8 @@ class Walker
 
 class Manifest
   constructor: (@config) ->
+    # By default, ignore hidden files and files in hidden directories.
+    @ignore = @config.appcache.ignore ? /[/][.]/
 
   brunchPlugin: true
 
@@ -50,7 +52,7 @@ class Manifest
     paths = []
     walker = new Walker
     walker.walk @config.paths.public, (path) =>
-      paths.push path unless /[.]appcache$/.test path
+      paths.push path unless /[.]appcache$/.test(path) or @ignore.test(path)
       unless walker.walking
         shasums = []
         paths.sort()


### PR DESCRIPTION
A few thoughts:
- I spent some time deciding whether to call this setting "exclude" or "ignore". I went with the latter as the setting serves a similar purpose to .gitignore, .hgignore, etc.
- Another approach would be to instead have a setting for paths to _include_, but I think _everything except these_ is more intuitive.
- Should certain paths be ignored by default? If so, which ones? .DS_Store? Others?
