### PR TITLE
Settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ A regular expression specifying paths to omit from the manifest.
 
 Default value : `/[/][.]/` (hidden files and files in hidden directories are ignored)
 
+### appcache.externalCacheEntries
+
+An array of additionals URIs added to `CACHE` section. For example:
+
+```coffeescript
+externalCacheEntries: [
+  'http://other.example.org/image.jpg'
+  # ...
+]
+```
+
+Default value : `[]`
+
 ### appcache.network
 
 An array of resource URIs which require a network connection added to `NETWORK` section. For example:

--- a/lib/index.js
+++ b/lib/index.js
@@ -79,6 +79,7 @@ Manifest = (function() {
     }
     this.options = {
       ignore: /[\\/][.]/,
+      externalCacheEntries: [],
       network: ['*'],
       fallback: {},
       staticRoot: '.',
@@ -158,7 +159,7 @@ Manifest = (function() {
         _results.push("" + this.options.staticRoot + "/" + p);
       }
       return _results;
-    }).call(this)).join('\n')));
+    }).call(this)).join('\n')) + "\n" + (this.options.externalCacheEntries.join('\n')));
   };
 
   return Manifest;

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -50,6 +50,7 @@ class Manifest
     # Defaults options
     @options = {
       ignore: /[\\/][.]/
+      externalCacheEntries: []
       network: ['*']
       fallback: {}
       staticRoot: '.'
@@ -99,6 +100,7 @@ class Manifest
 
       CACHE:
       #{("#{@options.staticRoot}/#{p}" for p in paths).join('\n')}
+      #{@options.externalCacheEntries.join('\n')}
     """
 
 


### PR DESCRIPTION
Proposal from the #7 comment thread.
- It was a bit complex to get things right without revert to 1.7.0, what I've done before new clear commits. Sorry for the mainline.
- Since you "deepFreeze" the config object, we can't easily use the (nice) syntax from brunch/src/helpers.coffee @es128 suggest. I kept the default hash and added the `config.plugin?` check from https://github.com/brunch/auto-reload-brunch/blob/master/src/index.coffee#L11:L13
- Coffee, JS & README are synced on each commits.

++
