### PR TITLE
fix wrong slash direction caused by Windows machines

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -80,7 +80,7 @@ class Manifest
             if shasums.length is paths.length
               shasum = crypto.createHash 'sha1'
               shasum.update shasums.sort().join(), 'ascii'
-              @write((pathlib.relative @config.paths.public, p for p in paths),
+              @write((pathlib.relative @config.paths.public, p for p in paths).replace /\\/g '/',
                      shasum.digest 'hex')
 
   format = (obj) ->


### PR DESCRIPTION
This will require a test (not fluent in CoffeeScript, didnt test actuallly code) but essentially the below needs to happen so that the file paths work properly for Windows developers.

Files didnt cache without putting the slash the correct way.

```javascript
for (_i = 0, _len = paths.length; _i < _len; _i++) {
  p = paths[_i];
  p = pathlib.relative(this.config.paths["public"], p);
  p = p.replace(/\\/g,'/');
  _results.push(p);
}
```